### PR TITLE
Admin route fix

### DIFF
--- a/src/components/admin-login-form.tsx
+++ b/src/components/admin-login-form.tsx
@@ -52,7 +52,7 @@ export function AdminLoginForm({ className, onSwitchToSignup, ...props }: AdminL
 						const role = res.data.data.account.role;
 
 						if (role === AccountRole.Admin) {
-							navigate("/admin");
+							navigate("/admin/dashboard");
 						} else {
 							console.error("Vai trò không phù hợp với đăng nhập admin:", role);
 							toast.error("Tài khoản này không có quyền truy cập admin. Vui lòng kiểm tra lại.");

--- a/src/pages/AdminLogin.tsx
+++ b/src/pages/AdminLogin.tsx
@@ -17,7 +17,7 @@ export default function AdminLoginPage() {
 		if (!isLoaded) return; // Chờ Clerk load xong
 
 		if (isSignedIn) {
-			navigate("/admin", { replace: true }); // Nếu đã đăng nhập thì redirect về admin dashboard
+			navigate("/admin/dashboard", { replace: true }); // Nếu đã đăng nhập thì redirect về admin dashboard
 		} else {
 			setShouldRender(true); // Cho phép render login page nếu chưa đăng nhập
 		}


### PR DESCRIPTION
This pull request updates the navigation paths for admin users to ensure they are directed to the correct dashboard page. The changes primarily involve modifying the `navigate` function calls to use `/admin/dashboard` instead of `/admin`.

### Navigation updates:

* [`src/components/admin-login-form.tsx`](diffhunk://#diff-63ab3314c5ac1262a4ae46fa56c47fe4762cf18d95352f79554075a19290ef95L55-R55): Updated the navigation path in the `AdminLoginForm` component to redirect admin users to `/admin/dashboard` after login.
* [`src/pages/AdminLogin.tsx`](diffhunk://#diff-f13896fd451b82f76beae178ff7845b84918e9381cfb73632a46298ada68344aL20-R20): Adjusted the redirection logic in the `AdminLoginPage` component to send signed-in users to `/admin/dashboard` instead of `/admin`.